### PR TITLE
Add Darkmoon (open source autonomous AI pentest, MCP host)

### DIFF
--- a/进攻性AI.md
+++ b/进攻性AI.md
@@ -139,6 +139,7 @@ docker run --rm -p 127.0.0.1:3000:3000 bkimminich/juice-shop
 更多AI漏洞扫描可以查看以下工具：
 
 + https://github.com/samugit83/redamon
++ https://github.com/ASCIT31/Dark-Moon
 + https://github.com/vxcontrol/pentagi
 + https://github.com/CyberSecurityUP/NeuroSploit
 + https://github.com/PurpleAILAB/Decepticon


### PR DESCRIPTION
Adds Darkmoon, an open source (GPL-3.0) autonomous AI penetration testing platform and MCP host that orchestrates 80+ offensive security tools with proof of exploitation and a local Privacy Gateway. Repo https://github.com/ASCIT31/Dark-Moon , site https://dark-moon.org